### PR TITLE
[MODI-120] 파티 목록 조회 API 응답에 파티 기간 추가

### DIFF
--- a/src/main/java/com/prgrms/modi/party/domain/Party.java
+++ b/src/main/java/com/prgrms/modi/party/domain/Party.java
@@ -29,10 +29,10 @@ public class Party extends BaseEntity {
     private Long id;
 
     @Positive
-    private Integer maxMemberCapacity;
+    private Integer partyMemberCapacity;
 
     @Positive
-    private Integer currentMemberCapacity;
+    private Integer currentMember;
 
     @PositiveOrZero
     private Integer totalFee;
@@ -72,8 +72,8 @@ public class Party extends BaseEntity {
 
     private Party(Builder builder) {
         id = builder.id;
-        maxMemberCapacity = builder.maxMemberCapacity;
-        currentMemberCapacity = builder.currentMemberCapacity;
+        partyMemberCapacity = builder.partyMemberCapacity;
+        currentMember = builder.currentMember;
         totalFee = builder.totalFee;
         monthlyReimbursement = builder.monthlyReimbursement;
         remainingReimbursement = builder.remainingReimbursement;
@@ -91,12 +91,12 @@ public class Party extends BaseEntity {
         return id;
     }
 
-    public Integer getMaxMemberCapacity() {
-        return maxMemberCapacity;
+    public Integer getPartyMemberCapacity() {
+        return partyMemberCapacity;
     }
 
-    public Integer getCurrentMemberCapacity() {
-        return currentMemberCapacity;
+    public Integer getCurrentMember() {
+        return currentMember;
     }
 
     public Integer getTotalFee() {
@@ -151,9 +151,9 @@ public class Party extends BaseEntity {
 
         private Long id;
 
-        private Integer maxMemberCapacity;
+        private Integer partyMemberCapacity;
 
-        private Integer currentMemberCapacity;
+        private Integer currentMember;
 
         private Integer totalFee;
 
@@ -186,12 +186,12 @@ public class Party extends BaseEntity {
         }
 
         public Builder partyMemberCapacity(Integer partyMemberCapacity) {
-            this.maxMemberCapacity = partyMemberCapacity;
+            this.partyMemberCapacity = partyMemberCapacity;
             return this;
         }
 
-        public Builder currentMemberCapacity(Integer currentMemberCapacity) {
-            this.currentMemberCapacity = currentMemberCapacity;
+        public Builder currentMember(Integer currentMember) {
+            this.currentMember = currentMember;
             return this;
         }
 

--- a/src/main/java/com/prgrms/modi/party/dto/response/PartyResponse.java
+++ b/src/main/java/com/prgrms/modi/party/dto/response/PartyResponse.java
@@ -1,6 +1,7 @@
 package com.prgrms.modi.party.dto.response;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MONTHS;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.prgrms.modi.party.domain.Party;
@@ -13,11 +14,11 @@ public class PartyResponse {
 
     private String grade;
 
-    private Integer price;
+    private Integer totalPrice;
 
-    private Integer maxMemberCapacity;
+    private Integer partyMemberCapacity;
 
-    private Integer currentMemberCapacity;
+    private Integer currentMember;
 
     private LocalDate startDate;
 
@@ -25,7 +26,22 @@ public class PartyResponse {
 
     private Integer startsIn;
 
+    private Integer period;
+
     private boolean mustFilled;
+
+    private PartyResponse(Builder builder) {
+        partyId = builder.partyId;
+        grade = builder.grade;
+        totalPrice = builder.totalPrice;
+        partyMemberCapacity = builder.partyMemberCapacity;
+        currentMember = builder.currentMember;
+        startDate = builder.startDate;
+        endDate = builder.endDate;
+        startsIn = builder.startsIn;
+        period = builder.period;
+        mustFilled = builder.mustFilled;
+    }
 
     public Long getPartyId() {
         return partyId;
@@ -35,16 +51,16 @@ public class PartyResponse {
         return grade;
     }
 
-    public Integer getPrice() {
-        return price;
+    public Integer getTotalPrice() {
+        return totalPrice;
     }
 
-    public Integer getMaxMemberCapacity() {
-        return maxMemberCapacity;
+    public Integer getPartyMemberCapacity() {
+        return partyMemberCapacity;
     }
 
-    public Integer getCurrentMemberCapacity() {
-        return currentMemberCapacity;
+    public Integer getCurrentMember() {
+        return currentMember;
     }
 
     public LocalDate getStartDate() {
@@ -59,38 +75,108 @@ public class PartyResponse {
         return startsIn;
     }
 
+    public Integer getPeriod() {
+        return period;
+    }
+
     public boolean isMustFilled() {
         return mustFilled;
     }
 
-    private PartyResponse(
-        Long partyId, String grade, Integer price,
-        Integer maxMemberCapacity, Integer currentMemberCapacity, LocalDate startDate,
-        LocalDate endDate, Integer startsIn, boolean mustFilled
-    ) {
-        this.partyId = partyId;
-        this.grade = grade;
-        this.price = price;
-        this.maxMemberCapacity = maxMemberCapacity;
-        this.currentMemberCapacity = currentMemberCapacity;
-        this.startDate = startDate;
-        this.endDate = endDate;
-        this.startsIn = startsIn;
-        this.mustFilled = mustFilled;
+    public static PartyResponse from(Party party) {
+        return new Builder()
+            .partyId(party.getId())
+            .grade(party.getOtt().getGrade())
+            .totalPrice(party.getTotalFee())
+            .partyMemberCapacity(party.getPartyMemberCapacity())
+            .currentMember(party.getCurrentMember())
+            .startDate(party.getStartDate())
+            .endDate(party.getEndDate())
+            .startsIn((int) DAYS.between(LocalDate.now(), party.getStartDate()))
+            .period((int) MONTHS.between(party.getStartDate(), party.getEndDate()))
+            .mustFilled(party.isMustFilled())
+            .build();
     }
 
-    public static PartyResponse from(Party party) {
-        return new PartyResponse(
-            party.getId(),
-            party.getOtt().getGrade(),
-            party.getTotalFee(),
-            party.getMaxMemberCapacity(),
-            party.getCurrentMemberCapacity(),
-            party.getStartDate(),
-            party.getEndDate(),
-            (int) DAYS.between(LocalDate.now(), party.getStartDate()),
-            party.isMustFilled()
-        );
+    private static final class Builder {
+
+        private Long partyId;
+
+        private String grade;
+
+        private Integer totalPrice;
+
+        private Integer partyMemberCapacity;
+
+        private Integer currentMember;
+
+        private LocalDate startDate;
+
+        private LocalDate endDate;
+
+        private Integer startsIn;
+
+        private Integer period;
+
+        private boolean mustFilled;
+
+        public Builder() {
+        }
+
+        public Builder partyId(Long partyId) {
+            this.partyId = partyId;
+            return this;
+        }
+
+        public Builder grade(String grade) {
+            this.grade = grade;
+            return this;
+        }
+
+        public Builder totalPrice(Integer totalPrice) {
+            this.totalPrice = totalPrice;
+            return this;
+        }
+
+        public Builder partyMemberCapacity(Integer partyMemberCapacity) {
+            this.partyMemberCapacity = partyMemberCapacity;
+            return this;
+        }
+
+        public Builder currentMember(Integer currentMember) {
+            this.currentMember = currentMember;
+            return this;
+        }
+
+        public Builder startDate(LocalDate startDate) {
+            this.startDate = startDate;
+            return this;
+        }
+
+        public Builder endDate(LocalDate endDate) {
+            this.endDate = endDate;
+            return this;
+        }
+
+        public Builder startsIn(Integer startsIn) {
+            this.startsIn = startsIn;
+            return this;
+        }
+
+        public Builder period(Integer period) {
+            this.period = period;
+            return this;
+        }
+
+        public Builder mustFilled(boolean mustFilled) {
+            this.mustFilled = mustFilled;
+            return this;
+        }
+
+        public PartyResponse build() {
+            return new PartyResponse(this);
+        }
+
     }
 
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -14,7 +14,7 @@ VALUES
     (4, '와챠', 10000, 2500, 4, '프리미엄', '2021-11-01 06:30:00', '2021-11-01 06:30:00'),
     (5, '티빙', 10000, 2500, 4, '프리미엄', '2021-11-01 06:30:00', '2021-11-01 06:30:00');
 
-INSERT INTO parties(id, max_member_capacity, current_member_capacity, total_fee, monthly_reimbursement, remaining_reimbursement, start_date, end_date,
+INSERT INTO parties(id, party_member_capacity, current_member, total_fee, monthly_reimbursement, remaining_reimbursement, start_date, end_date,
                     must_filled, shared_id, shared_password_encrypted, status, created_at, updated_at, deleted_at, ott_id)
 VALUES
     (1, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),

--- a/src/test/java/com/prgrms/modi/party/PartyServiceTest.java
+++ b/src/test/java/com/prgrms/modi/party/PartyServiceTest.java
@@ -69,27 +69,29 @@ class PartyServiceTest {
         int size = 5;
 
         OTT ott = getOttFixture(ottId);
+        int period = 12;
+
         Party party1 = new Party.Builder()
             .id(1L)
             .partyMemberCapacity(4)
-            .currentMemberCapacity(1)
+            .currentMember(1)
             .totalFee(1000)
             .monthlyReimbursement(2000)
             .remainingReimbursement(8000)
             .startDate(LocalDate.now())
-            .endDate(LocalDate.now().plusMonths(12))
+            .endDate(LocalDate.now().plusMonths(period))
             .mustFilled(true)
             .ott(ott)
             .build();
         Party party2 = new Party.Builder()
             .id(2L)
             .partyMemberCapacity(4)
-            .currentMemberCapacity(1)
+            .currentMember(1)
             .totalFee(1000)
             .monthlyReimbursement(2000)
             .remainingReimbursement(8000)
             .startDate(LocalDate.now())
-            .endDate(LocalDate.now().plusMonths(12))
+            .endDate(LocalDate.now().plusMonths(period))
             .mustFilled(true)
             .ott(ott)
             .build();
@@ -106,6 +108,7 @@ class PartyServiceTest {
 
         // Then
         assertThat(response.getPartyList().size(), equalTo(2));
+        assertThat(response.getPartyList().get(0).getPeriod(), equalTo(period));
     }
 
     @Test
@@ -120,7 +123,7 @@ class PartyServiceTest {
         Party party1 = new Party.Builder()
             .id(1L)
             .partyMemberCapacity(4)
-            .currentMemberCapacity(1)
+            .currentMember(1)
             .totalFee(1000)
             .monthlyReimbursement(2000)
             .remainingReimbursement(8000)
@@ -132,7 +135,7 @@ class PartyServiceTest {
         Party party2 = new Party.Builder()
             .id(2L)
             .partyMemberCapacity(4)
-            .currentMemberCapacity(1)
+            .currentMember(1)
             .totalFee(1000)
             .monthlyReimbursement(2000)
             .remainingReimbursement(8000)
@@ -181,7 +184,7 @@ class PartyServiceTest {
         Party party = new Party.Builder()
             .id(1L)
             .partyMemberCapacity(createPartyRequest.getPartyMemberCapacity())
-            .currentMemberCapacity(1)
+            .currentMember(1)
             .totalFee(1000)
             .monthlyReimbursement(2000)
             .remainingReimbursement(8000)


### PR DESCRIPTION
- 파티 기간 추가 이외에 다음과 같은 작업을 했습니다
  - 파티 엔티티의 maxMemberCapacity를 partyMemberCapacity로 수정 (OTT 엔티티의 필드와 혼선 방지)
  - 파티 엔티티의 currentMemberCapacity를 currentMember로 수정 (남은 자리가 아니라 참여중인 멤버 수 표현을 위해)
  - 모든 필드를 받는 partyresponse의 private 생성자를 빌더로 대체했습니다
  - data.sql의 필드명 수정
  - 서비스 유닛 테스트에 기간 테스트 추가 