### PR TITLE
[MODI-112] 전체 규칙 조회 API

### DIFF
--- a/src/main/java/com/prgrms/modi/party/controller/PartyController.java
+++ b/src/main/java/com/prgrms/modi/party/controller/PartyController.java
@@ -5,8 +5,9 @@ import com.prgrms.modi.error.exception.InvalidAuthenticationException;
 import com.prgrms.modi.party.dto.request.CreatePartyRequest;
 import com.prgrms.modi.party.dto.response.PartyIdResponse;
 import com.prgrms.modi.party.dto.response.PartyListResponse;
+import com.prgrms.modi.party.dto.response.RuleListResponse;
 import com.prgrms.modi.party.service.PartyService;
-import com.prgrms.modi.user.service.UserService;
+import com.prgrms.modi.party.service.RuleService;
 import javax.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,11 +27,11 @@ public class PartyController {
 
     private final PartyService partyService;
 
-    private final UserService userService;
+    private final RuleService ruleService;
 
-    public PartyController(PartyService partyService, UserService userService) {
+    public PartyController(PartyService partyService, RuleService ruleService) {
         this.partyService = partyService;
-        this.userService = userService;
+        this.ruleService = ruleService;
     }
 
     @GetMapping("/otts/{ottId}/parties")
@@ -55,6 +56,11 @@ public class PartyController {
             throw new InvalidAuthenticationException("인증되지 않는 사용자입니다");
         }
         return ResponseEntity.ok(partyService.createParty(request, authentication.userId));
+    }
+
+    @GetMapping("/rules")
+    public ResponseEntity<RuleListResponse> getRuleList() {
+        return ResponseEntity.ok(ruleService.getAllRule());
     }
 
 }

--- a/src/main/java/com/prgrms/modi/party/domain/Rule.java
+++ b/src/main/java/com/prgrms/modi/party/domain/Rule.java
@@ -1,7 +1,6 @@
 package com.prgrms.modi.party.domain;
 
 import com.prgrms.modi.common.domain.BaseEntity;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -19,5 +18,13 @@ public class Rule extends BaseEntity {
 
     @NotBlank
     private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
 
 }

--- a/src/main/java/com/prgrms/modi/party/dto/response/RuleListResponse.java
+++ b/src/main/java/com/prgrms/modi/party/dto/response/RuleListResponse.java
@@ -1,0 +1,24 @@
+package com.prgrms.modi.party.dto.response;
+
+import java.util.List;
+
+public class RuleListResponse {
+
+    private List<RuleResponse> rules;
+
+    public List<RuleResponse> getRules() {
+        return rules;
+    }
+
+    protected RuleListResponse() {
+    }
+
+    private RuleListResponse(List<RuleResponse> rules) {
+        this.rules = rules;
+    }
+
+    public static RuleListResponse from(List<RuleResponse> rules) {
+        return new RuleListResponse(rules);
+    }
+
+}

--- a/src/main/java/com/prgrms/modi/party/dto/response/RuleResponse.java
+++ b/src/main/java/com/prgrms/modi/party/dto/response/RuleResponse.java
@@ -1,0 +1,31 @@
+package com.prgrms.modi.party.dto.response;
+
+import com.prgrms.modi.party.domain.Rule;
+
+public class RuleResponse {
+
+    private Long ruleId;
+
+    private String ruleName;
+
+    protected RuleResponse() {
+    }
+
+    private RuleResponse(Rule rule) {
+        this.ruleId = rule.getId();
+        this.ruleName = rule.getName();
+    }
+
+    public Long getRuleId() {
+        return ruleId;
+    }
+
+    public String getRuleName() {
+        return ruleName;
+    }
+
+    public static RuleResponse from(Rule rule) {
+        return new RuleResponse(rule);
+    }
+
+}

--- a/src/main/java/com/prgrms/modi/party/service/RuleService.java
+++ b/src/main/java/com/prgrms/modi/party/service/RuleService.java
@@ -2,14 +2,17 @@ package com.prgrms.modi.party.service;
 
 import com.prgrms.modi.error.exception.NotFoundException;
 import com.prgrms.modi.party.domain.Rule;
+import com.prgrms.modi.party.dto.response.RuleListResponse;
+import com.prgrms.modi.party.dto.response.RuleResponse;
 import com.prgrms.modi.party.repository.RuleRepository;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RuleService {
 
     private final RuleRepository ruleRepository;
-    
+
     public RuleService(RuleRepository ruleRepository) {
         this.ruleRepository = ruleRepository;
     }
@@ -17,6 +20,17 @@ public class RuleService {
     public Rule findRule(Long id) {
         return ruleRepository.findById(id)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 규칙입니다"));
+    }
+
+    public RuleListResponse getAllRule() {
+        return RuleListResponse.from(
+            ruleRepository.findAll()
+                .stream()
+                .map(RuleResponse::from)
+                .collect(Collectors.toList())
+        );
+
+
     }
 
 }

--- a/src/main/java/com/prgrms/modi/party/service/RuleService.java
+++ b/src/main/java/com/prgrms/modi/party/service/RuleService.java
@@ -29,8 +29,6 @@ public class RuleService {
                 .map(RuleResponse::from)
                 .collect(Collectors.toList())
         );
-
-
     }
 
 }

--- a/src/test/java/com/prgrms/modi/party/PartyControllerTest.java
+++ b/src/test/java/com/prgrms/modi/party/PartyControllerTest.java
@@ -149,4 +149,18 @@ class PartyControllerTest {
         assertThat(maybeParty.getSharedId(), equalTo("modi@gmail.com"));
     }
 
+    @Test
+    @DisplayName("모든 규칙 태그를 조회할 수 있다")
+    public void getAllRule() throws Exception {
+        // When
+        mockMvc
+            .perform(get("/api/rules"))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.rules[0].ruleId").value(1),
+                jsonPath("$.rules[0].ruleName").value("1인 1회선")
+            )
+            .andDo(print());
+    }
+
 }

--- a/src/test/java/com/prgrms/modi/party/service/RuleServiceTest.java
+++ b/src/test/java/com/prgrms/modi/party/service/RuleServiceTest.java
@@ -51,6 +51,5 @@ class RuleServiceTest {
         verify(ruleRepository, times(1)).findAll();
         assertThat(ruleList.getRules().size(), equalTo(ruleSize));
     }
-
-
+    
 }

--- a/src/test/java/com/prgrms/modi/party/service/RuleServiceTest.java
+++ b/src/test/java/com/prgrms/modi/party/service/RuleServiceTest.java
@@ -1,0 +1,56 @@
+package com.prgrms.modi.party.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.prgrms.modi.party.domain.Rule;
+import com.prgrms.modi.party.dto.response.RuleListResponse;
+import com.prgrms.modi.party.repository.RuleRepository;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RuleServiceTest {
+
+    @InjectMocks
+    RuleService ruleService;
+
+    @Mock
+    RuleRepository ruleRepository;
+
+    @Test
+    @DisplayName("모든 규칙 태그를 조회할 수 있다")
+    public void getAllRule() {
+        // Given
+        int ruleSize = 5;
+        List<Rule> rules = new ArrayList<>();
+        for (int i = 0; i < ruleSize; i++) {
+            Rule mockRule = Mockito.mock(Rule.class);
+            doReturn((long) i).when(mockRule).getId();
+            doReturn("테스트 규칙 " + i).when(mockRule).getName();
+            rules.add(mockRule);
+        }
+
+        when(ruleRepository.findAll()).thenReturn(rules);
+
+        // When
+        RuleListResponse ruleList = ruleService.getAllRule();
+
+        // Then
+        verify(ruleRepository, times(1)).findAll();
+        assertThat(ruleList.getRules().size(), equalTo(ruleSize));
+    }
+
+
+}


### PR DESCRIPTION
- 모든 규칙 태그를 조회하는 API를 구현했습니다
- 요청 응답 형태 : [지라 티켓](https://sangmin7648.atlassian.net/jira/software/projects/MODI/boards/1?assignee=610772bf0b454a0068f9435c&selectedIssue=MODI-112)
