### PR TITLE
[MODI-82] 유저가 참여한 파티 상세 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ jacocoTestReport {
                     excludes: [
                             '**/com/prgrms/modi/error/**',
                             '**/com/prgrms/modi/common/**',
+                            '**/com/prgrms/modi/utils/**'
                     ]
             )
         }))

--- a/src/main/java/com/prgrms/modi/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/modi/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.prgrms.modi.user.controller;
 
 import com.prgrms.modi.common.jwt.JwtAuthentication;
+import com.prgrms.modi.error.exception.InvalidAuthenticationException;
 import com.prgrms.modi.error.exception.InvalidAuthorizationException;
 import com.prgrms.modi.party.dto.response.PartyDetailResponse;
 import com.prgrms.modi.party.service.PartyService;

--- a/src/main/java/com/prgrms/modi/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/modi/user/controller/UserController.java
@@ -2,26 +2,40 @@ package com.prgrms.modi.user.controller;
 
 import com.prgrms.modi.common.jwt.JwtAuthentication;
 import com.prgrms.modi.error.exception.InvalidAuthenticationException;
+import com.prgrms.modi.error.exception.InvalidAuthorizationException;
+import com.prgrms.modi.party.dto.response.PartyDetailResponse;
+import com.prgrms.modi.party.service.PartyService;
 import com.prgrms.modi.user.dto.PointAmountDto;
 import com.prgrms.modi.user.dto.UserResponse;
 import com.prgrms.modi.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import javax.validation.constraints.Positive;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/api/users")
 public class UserController {
 
+    private Logger log = LoggerFactory.getLogger(getClass());
+
     private final UserService userService;
 
-    public UserController(UserService userService) {
+    private final PartyService partyService;
+
+    public UserController(UserService userService, PartyService partyService) {
         this.userService = userService;
+        this.partyService = partyService;
     }
 
     @GetMapping(path = "/me")
@@ -54,6 +68,26 @@ public class UserController {
         }
         return ResponseEntity.ok(
             userService.getUserPoints(authentication.userId));
+    }
+
+
+    @GetMapping("/me/parties/{partyId}")
+    @Operation(summary = "유저 참여 파티 상세 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "유저 참여 파티 정보 조회 성공 (OK)"),
+        @ApiResponse(responseCode = "401", description = "토큰이 없거나 다른 파티의 상세 정보에 접근할 때 (UNAUTHORIZED)")
+    })
+    public ResponseEntity<PartyDetailResponse> getUserPartyDetail(
+        @Parameter(name = "partyId", description = "조회할 파티 id") @PathVariable @Positive Long partyId,
+        @ApiIgnore @AuthenticationPrincipal JwtAuthentication authentication
+    ) {
+        if (authentication == null) {
+            throw new InvalidAuthenticationException("인증되지 않는 사용자입니다");
+        }
+        if (partyService.notPartyMember(partyId, authentication.userId)) {
+            throw new InvalidAuthorizationException("인가되지 않은 사용자입니다");
+        }
+        return ResponseEntity.ok(userService.getUserPartyDetail(partyId));
     }
 
 }

--- a/src/main/java/com/prgrms/modi/user/service/UserService.java
+++ b/src/main/java/com/prgrms/modi/user/service/UserService.java
@@ -12,9 +12,8 @@ import com.prgrms.modi.history.domain.CommissionDetail;
 import com.prgrms.modi.history.domain.PointDetail;
 import com.prgrms.modi.history.service.CommissionHistoryService;
 import com.prgrms.modi.history.service.PointHistoryService;
-import com.prgrms.modi.party.domain.Party;
-import com.prgrms.modi.party.dto.response.PartyDetailResponse;
 import com.prgrms.modi.party.domain.PartyStatus;
+import com.prgrms.modi.party.dto.response.PartyDetailResponse;
 import com.prgrms.modi.party.repository.PartyRepository;
 import com.prgrms.modi.user.domain.Role;
 import com.prgrms.modi.user.domain.User;
@@ -22,11 +21,9 @@ import com.prgrms.modi.user.dto.PointAmountDto;
 import com.prgrms.modi.user.dto.UserPartyListResponse;
 import com.prgrms.modi.user.dto.UserResponse;
 import com.prgrms.modi.user.repository.UserRepository;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -45,8 +42,6 @@ public class UserService {
     private final PointHistoryService pointHistoryService;
 
     private final CommissionHistoryService commissionHistoryService;
-
-    private final PartyRepository partyRepository;
 
     public UserService(
         UserRepository userRepository,
@@ -154,7 +149,7 @@ public class UserService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 파티입니다")));
     }
 
-    @Transactional(readOnly = true)  
+    @Transactional(readOnly = true)
     public UserPartyListResponse getUserPartyList(Long userId, PartyStatus partyStatus, Integer size,
         Long lastPartyId) {
         return new UserPartyListResponse(

--- a/src/main/java/com/prgrms/modi/user/service/UserService.java
+++ b/src/main/java/com/prgrms/modi/user/service/UserService.java
@@ -13,6 +13,8 @@ import com.prgrms.modi.history.domain.PointDetail;
 import com.prgrms.modi.history.service.CommissionHistoryService;
 import com.prgrms.modi.history.service.PointHistoryService;
 import com.prgrms.modi.party.domain.Party;
+import com.prgrms.modi.party.dto.response.PartyDetailResponse;
+import com.prgrms.modi.party.repository.PartyRepository;
 import com.prgrms.modi.user.domain.Role;
 import com.prgrms.modi.user.domain.User;
 import com.prgrms.modi.user.dto.PointAmountDto;
@@ -40,14 +42,17 @@ public class UserService {
 
     private final CommissionHistoryService commissionHistoryService;
 
+    private final PartyRepository partyRepository;
+
     public UserService(
         UserRepository userRepository,
         PointHistoryService pointHistoryService,
-        CommissionHistoryService commissionHistoryService
-    ) {
+        CommissionHistoryService commissionHistoryService,
+        PartyRepository partyRepository) {
         this.userRepository = userRepository;
         this.pointHistoryService = pointHistoryService;
         this.commissionHistoryService = commissionHistoryService;
+        this.partyRepository = partyRepository;
     }
 
     @Transactional(readOnly = true)
@@ -132,6 +137,15 @@ public class UserService {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new NotFoundException("유저가 없습니다."));
         return new PointAmountDto(user.getPoints());
+    }
+
+    @Transactional(readOnly = true)
+    public PartyDetailResponse getUserPartyDetail(Long partyId) {
+        log.info("[*] partyId: {}", partyId);
+        return PartyDetailResponse.from(
+            partyRepository.findById(partyId)
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 파티입니다"))
+        );
     }
 
 }

--- a/src/test/java/com/prgrms/modi/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/modi/user/controller/UserControllerTest.java
@@ -1,5 +1,6 @@
 package com.prgrms.modi.user.controller;
 
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
@@ -28,7 +29,7 @@ class UserControllerTest {
 
     @Test
     @WithMockJwtAuthentication
-    @DisplayName("유저 정보 조회 성공 테스트")
+    @DisplayName("유저의 정보를 조회할 수 있다")
     void getUserSuccessTest() throws Exception {
         int userId = 1;
         mockMvc
@@ -49,7 +50,7 @@ class UserControllerTest {
 
     @Test
     @WithMockJwtAuthentication
-    @DisplayName("유저 포인트 조회 테스트")
+    @DisplayName("유저의 포인트를 조회할 수 있다")
     void getUserPointsSuccessTest() throws Exception {
         mockMvc
             .perform(
@@ -61,6 +62,26 @@ class UserControllerTest {
                 handler().handlerType(UserController.class),
                 handler().methodName("getUserPoints"),
                 jsonPath("$.points").value(50000)
+            )
+            .andDo(print());
+    }
+
+    @Test
+    @WithMockJwtAuthentication
+    @DisplayName("유저가 참여한 특정 파티를 조회할 수 있다")
+    public void getUserParty() throws Exception {
+        long partyId = 1L;
+
+        mockMvc
+            .perform(get("/api/users/me/parties/" + partyId))
+            .andExpectAll(
+                status().isOk(),
+                handler().handlerType(UserController.class),
+                handler().methodName("getUserPartyDetail"),
+                jsonPath("$.partyId").value(partyId),
+                jsonPath("$.ottId").value(1L),
+                jsonPath("$.members", hasSize(4)),
+                jsonPath("$.rules", hasSize(3))
             )
             .andDo(print());
     }

--- a/src/test/java/com/prgrms/modi/user/service/UserServiceTest.java
+++ b/src/test/java/com/prgrms/modi/user/service/UserServiceTest.java
@@ -1,10 +1,14 @@
 package com.prgrms.modi.user.service;
 
 import static com.prgrms.modi.user.domain.UserTest.getUserFixture;
+import static com.prgrms.modi.utils.MockCreator.getPartyFixture;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
+import com.prgrms.modi.party.domain.Party;
+import com.prgrms.modi.party.dto.response.PartyDetailResponse;
+import com.prgrms.modi.party.repository.PartyRepository;
 import com.prgrms.modi.user.domain.User;
 import com.prgrms.modi.user.dto.PointAmountDto;
 import com.prgrms.modi.user.dto.UserResponse;
@@ -28,6 +32,9 @@ class UserServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private PartyRepository partyRepository;
 
     @Test
     @DisplayName("유저를 조회할 수 있다.")
@@ -53,6 +60,20 @@ class UserServiceTest {
 
         then(pointAmountDto)
             .hasFieldOrPropertyWithValue("points", user.getPoints());
+    }
+
+    @Test
+    @DisplayName("유저가 참여한 파티 상세 정보를 조회할 수 있다.")
+    public void getUserPartyTest() {
+        User user = getUserFixture();
+        given(userRepository.findById(anyLong())).willReturn(Optional.of(user));
+        Party party = getPartyFixture(1L);
+        given(partyRepository.findById(party.getId())).willReturn(Optional.of(party));
+
+        PartyDetailResponse userPartyDetail = userService.getUserPartyDetail(party.getId());
+
+        then(userPartyDetail)
+            .hasNoNullFieldsOrProperties();
     }
 
 }


### PR DESCRIPTION
### 구현한 내용
* 기존에 파티 상세 정보 조회 API의 response와 status, periods만 다른데(유저 참여 파티 상세 조회에만 없음)
* 유저가 현재 참여하고 있는 파티의 상세 정보만 확인할 수 있도록 했는데 필요한 검증인지 궁금합니다.
* 추가로 utils 패키지는 jacoco에서 제외했습니다