### PR TITLE
[MODI-221] FEAT: 닉네임 랜덤생성 API 추가

### DIFF
--- a/src/main/java/com/prgrms/modi/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/modi/user/controller/UserController.java
@@ -9,18 +9,20 @@ import com.prgrms.modi.party.service.PartyService;
 import com.prgrms.modi.user.dto.PointAmountResponse;
 import com.prgrms.modi.user.dto.UserPartyListResponse;
 import com.prgrms.modi.user.dto.UserResponse;
+import com.prgrms.modi.user.dto.UsernameListResponse;
 import com.prgrms.modi.user.dto.UsernameResponse;
 import com.prgrms.modi.user.service.UserService;
-import com.prgrms.modi.utils.UsernameGenerator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.util.List;
 import javax.validation.constraints.Positive;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +32,7 @@ import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
 @RequestMapping("/api/users")
+@Validated
 public class UserController {
 
     private Logger log = LoggerFactory.getLogger(getClass());
@@ -127,9 +130,12 @@ public class UserController {
     @GetMapping("/generate-username")
     @Operation(summary = "랜덤 닉네임 생성", description = "랜덤 닉네임 생성 API")
     @ApiResponse(responseCode = "200", description = "OK")
-    public ResponseEntity<UsernameResponse> generateUsername() {
+    public ResponseEntity<UsernameListResponse> generateUsername(
+        @Parameter(name = "size", description = "생성할 닉네임 개수") @RequestParam @Positive Integer size
+    ) {
+        List<UsernameResponse> generateUsernames = userService.generateUsernames(size);
         return ResponseEntity.ok(
-            new UsernameResponse(UsernameGenerator.createRandomName()));
+            new UsernameListResponse(generateUsernames));
     }
 
 }

--- a/src/main/java/com/prgrms/modi/user/controller/UserController.java
+++ b/src/main/java/com/prgrms/modi/user/controller/UserController.java
@@ -9,7 +9,9 @@ import com.prgrms.modi.party.service.PartyService;
 import com.prgrms.modi.user.dto.PointAmountResponse;
 import com.prgrms.modi.user.dto.UserPartyListResponse;
 import com.prgrms.modi.user.dto.UserResponse;
+import com.prgrms.modi.user.dto.UsernameResponse;
 import com.prgrms.modi.user.service.UserService;
+import com.prgrms.modi.utils.UsernameGenerator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -120,6 +122,14 @@ public class UserController {
         }
         PartyDetailResponse resp = userService.getUserPartyDetail(partyId);
         return ResponseEntity.ok(resp);
+    }
+
+    @GetMapping("/generate-username")
+    @Operation(summary = "랜덤 닉네임 생성", description = "랜덤 닉네임 생성 API")
+    @ApiResponse(responseCode = "200", description = "OK")
+    public ResponseEntity<UsernameResponse> generateUsername() {
+        return ResponseEntity.ok(
+            new UsernameResponse(UsernameGenerator.createRandomName()));
     }
 
 }

--- a/src/main/java/com/prgrms/modi/user/dto/UsernameListResponse.java
+++ b/src/main/java/com/prgrms/modi/user/dto/UsernameListResponse.java
@@ -1,0 +1,18 @@
+package com.prgrms.modi.user.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsernameListResponse {
+
+    private List<UsernameResponse> generatedUsernames = new ArrayList<>();
+
+    public UsernameListResponse(List<UsernameResponse> generatedUsernames) {
+        this.generatedUsernames = generatedUsernames;
+    }
+
+    public List<UsernameResponse> getGeneratedUsernames() {
+        return generatedUsernames;
+    }
+
+}

--- a/src/main/java/com/prgrms/modi/user/dto/UsernameResponse.java
+++ b/src/main/java/com/prgrms/modi/user/dto/UsernameResponse.java
@@ -1,0 +1,18 @@
+package com.prgrms.modi.user.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+
+public class UsernameResponse {
+
+    @ApiModelProperty(value = "생성된 닉네임")
+    String generatedUsername;
+
+    public UsernameResponse(String generatedUsername) {
+        this.generatedUsername = generatedUsername;
+    }
+
+    public String getGeneratedUsername() {
+        return generatedUsername;
+    }
+
+}

--- a/src/main/java/com/prgrms/modi/user/service/UserService.java
+++ b/src/main/java/com/prgrms/modi/user/service/UserService.java
@@ -19,7 +19,11 @@ import com.prgrms.modi.user.dto.PointAmountResponse;
 import com.prgrms.modi.user.dto.UserPartyBriefResponse;
 import com.prgrms.modi.user.dto.UserPartyListResponse;
 import com.prgrms.modi.user.dto.UserResponse;
+import com.prgrms.modi.user.dto.UsernameListResponse;
+import com.prgrms.modi.user.dto.UsernameResponse;
 import com.prgrms.modi.user.repository.UserRepository;
+import com.prgrms.modi.utils.UsernameGenerator;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.slf4j.Logger;
@@ -131,6 +135,17 @@ public class UserService {
     public User findUser(Long id) {
         return userRepository.findById(id)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 유저입니다."));
+    }
+
+    public List<UsernameResponse> generateUsernames(int size) {
+        List<UsernameResponse> usernames = new ArrayList<>();
+
+        for (int i = 0; i < size; i++) {
+            String generatedUsername = UsernameGenerator.createRandomName();
+            usernames.add(new UsernameResponse(generatedUsername));
+        }
+
+        return usernames;
     }
 
 }

--- a/src/test/java/com/prgrms/modi/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/modi/user/controller/UserControllerTest.java
@@ -166,12 +166,16 @@ class UserControllerTest {
     @Test
     @DisplayName("닉네임 자동생성 API 테스트")
     public void getGeneratedUsername() throws Exception {
+        int size = 5;
+
         mockMvc
-            .perform(get("/api/users/generate-username"))
+            .perform(
+                get("/api/users/generate-username?size=" + size))
             .andExpectAll(
                 status().isOk(),
-                jsonPath("$.generatedUsername").isNotEmpty()
-            );
+                jsonPath("$.generatedUsernames", hasSize(size)))
+            .andDo(
+                print());
     }
 
 }

--- a/src/test/java/com/prgrms/modi/user/controller/UserControllerTest.java
+++ b/src/test/java/com/prgrms/modi/user/controller/UserControllerTest.java
@@ -163,4 +163,15 @@ class UserControllerTest {
             .andDo(print());
     }
 
+    @Test
+    @DisplayName("닉네임 자동생성 API 테스트")
+    public void getGeneratedUsername() throws Exception {
+        mockMvc
+            .perform(get("/api/users/generate-username"))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.generatedUsername").isNotEmpty()
+            );
+    }
+
 }


### PR DESCRIPTION
닉네임을 랜덤으로 생성해 반환하는 API를 추가했습니다

요청
`GET /api/users/generate-username?size=3`

응답
```
{
  "generatedUsernames": [
    {
      "generatedUsername": "아니꼬운 매미"
    },
    {
      "generatedUsername": "의심쩍은 두꺼비"
    },
    {
      "generatedUsername": "않은 병아리"
    }
  ]
}

```