### PR TITLE
[MODI-225] 파티 공유 계정 수정 API 구현

### DIFF
--- a/src/main/java/com/prgrms/modi/party/controller/PartyController.java
+++ b/src/main/java/com/prgrms/modi/party/controller/PartyController.java
@@ -5,6 +5,7 @@ import com.prgrms.modi.error.exception.AlreadyJoinedException;
 import com.prgrms.modi.error.exception.ForbiddenException;
 import com.prgrms.modi.error.exception.InvalidAuthenticationException;
 import com.prgrms.modi.party.dto.request.CreatePartyRequest;
+import com.prgrms.modi.party.dto.request.UpdateSharedAccountRequest;
 import com.prgrms.modi.party.dto.response.PartyDetailResponse;
 import com.prgrms.modi.party.dto.response.PartyIdResponse;
 import com.prgrms.modi.party.dto.response.PartyListResponse;
@@ -20,6 +21,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -122,6 +124,28 @@ public class PartyController {
             throw new AlreadyJoinedException("이미 가입된 파티에 가입할 수 없습니다");
         }
         PartyIdResponse resp = partyService.joinParty(authentication.userId, partyId);
+        return ResponseEntity.ok(resp);
+    }
+
+    @PatchMapping("parties/{partyId}/sharedAccount/update")
+    @Operation(summary = "파티 공유 계정 수정", description = "파티장이 파티 공유 계정을 수정합니다.")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "파티 공유 계정 수정 후, 수정된 파티 ID를 응답으로 보내줍니다."),
+        @ApiResponse(responseCode = "401", description = "토큰이 없어 인증 할 수 경우"),
+        @ApiResponse(responseCode = "403", description = "파티장이 아닌 유저인 경우 FORBIDDEN")
+    })
+    public ResponseEntity<PartyIdResponse> updateSharedAccount(
+        @AuthenticationPrincipal @ApiIgnore JwtAuthentication authentication,
+        @Parameter(description = "파티의 ID") @PathVariable Long partyId,
+        @RequestBody @Valid final UpdateSharedAccountRequest request
+    ) {
+        if (authentication == null) {
+            throw new InvalidAuthenticationException("인증되지 않는 사용자입니다");
+        }
+        if (!partyService.isPartyLeader(partyId, authentication.userId)) {
+            throw new ForbiddenException("인가되지 않은 사용자입니다");
+        }
+        PartyIdResponse resp = partyService.updateSharedAccount(partyId, request);
         return ResponseEntity.ok(resp);
     }
 

--- a/src/main/java/com/prgrms/modi/party/domain/Party.java
+++ b/src/main/java/com/prgrms/modi/party/domain/Party.java
@@ -189,6 +189,10 @@ public class Party extends DeletableEntity {
         this.status = status;
     }
 
+    public void changeSharedAccount(String sharedPassword) {
+        this.sharedPasswordEncrypted = sharedPassword;
+    }
+
     public void setLeaderMember(User user) {
         Member leader = new Member(this, user, true);
         this.members.add(leader);

--- a/src/main/java/com/prgrms/modi/party/dto/request/UpdateSharedAccountRequest.java
+++ b/src/main/java/com/prgrms/modi/party/dto/request/UpdateSharedAccountRequest.java
@@ -1,0 +1,23 @@
+package com.prgrms.modi.party.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import javax.validation.constraints.NotBlank;
+
+public class UpdateSharedAccountRequest {
+
+    @ApiModelProperty(value = "공유 OTT 계정 비밀번호")
+    @NotBlank
+    private String sharedPassword;
+
+    protected UpdateSharedAccountRequest() {
+    }
+
+    public UpdateSharedAccountRequest(String sharedPassword) {
+        this.sharedPassword = sharedPassword;
+    }
+
+    public String getSharedPassword() {
+        return sharedPassword;
+    }
+
+}

--- a/src/main/java/com/prgrms/modi/party/service/PartyService.java
+++ b/src/main/java/com/prgrms/modi/party/service/PartyService.java
@@ -10,6 +10,7 @@ import com.prgrms.modi.party.domain.Party;
 import com.prgrms.modi.party.domain.PartyStatus;
 import com.prgrms.modi.party.domain.Rule;
 import com.prgrms.modi.party.dto.request.CreatePartyRequest;
+import com.prgrms.modi.party.dto.request.UpdateSharedAccountRequest;
 import com.prgrms.modi.party.dto.response.PartyBriefResponse;
 import com.prgrms.modi.party.dto.response.PartyDetailResponse;
 import com.prgrms.modi.party.dto.response.PartyIdResponse;
@@ -20,18 +21,17 @@ import com.prgrms.modi.party.repository.RuleRepository;
 import com.prgrms.modi.user.domain.Member;
 import com.prgrms.modi.user.domain.User;
 import com.prgrms.modi.user.repository.UserRepository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class PartyService {
@@ -186,6 +186,26 @@ public class PartyService {
         partyRepository.findByStatus(PartyStatus.ONGOING).stream()
             .filter(party -> Objects.equals(party.getEndDate(), today))
             .forEach(party -> party.changeStatus(PartyStatus.FINISHED));
+    }
+
+    @Transactional
+    public PartyIdResponse updateSharedAccount(Long partyId, UpdateSharedAccountRequest request) {
+        Party party = partyRepository.getById(partyId);
+        party.changeSharedAccount(request.getSharedPassword());
+        partyRepository.save(party);
+        return PartyIdResponse.from(party);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean isPartyLeader(Long partyId, Long userId) {
+        Party party = partyRepository.getById(partyId);
+        User user = userRepository.getById(userId);
+        for (Member member : party.getMembers()) {
+            if (member.isLeader() && member.getUser().equals(user)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Party createNewParty(CreatePartyRequest request, long userId) {


### PR DESCRIPTION
- 파티장만 파티의 공유계정을 수정할 수 있도록 했습니다.
- 추후에 계정 변경 알림 기능을 추가할 예정입니다.
- 테스트 자동 포맷팅 되면서 위치가 변경 되는 부분이 있네요?
- url에 update를 빼는게 좋을지 고민입니다.