### PR TITLE
[MODI-232] 파티 목록 조회 totalSize 오류 수정

### DIFF
--- a/src/main/java/com/prgrms/modi/party/dto/response/PartyListResponse.java
+++ b/src/main/java/com/prgrms/modi/party/dto/response/PartyListResponse.java
@@ -13,12 +13,12 @@ public class PartyListResponse {
     private String ottName;
 
     @ApiModelProperty(value = "OTT 파티목록 전체 size")
-    private Integer totalSize;
+    private long totalSize;
 
     @ApiModelProperty(value = "간략한 파티 정보")
     private List<PartyBriefResponse> partyList;
 
-    public PartyListResponse(Long ottId, String ottName, Integer totalSize, List<PartyBriefResponse> partyList) {
+    public PartyListResponse(Long ottId, String ottName, long totalSize, List<PartyBriefResponse> partyList) {
         this.ottId = ottId;
         this.ottName = ottName;
         this.totalSize = totalSize;
@@ -33,7 +33,7 @@ public class PartyListResponse {
         return ottName;
     }
 
-    public Integer getTotalSize() {
+    public long getTotalSize() {
         return totalSize;
     }
 
@@ -41,7 +41,7 @@ public class PartyListResponse {
         return partyList;
     }
 
-    public static PartyListResponse from(OTT ott, Integer totalSize, List<PartyBriefResponse> parties) {
+    public static PartyListResponse from(OTT ott, long totalSize, List<PartyBriefResponse> parties) {
         return new PartyListResponse(
             ott.getId(),
             ott.getName(),

--- a/src/main/java/com/prgrms/modi/party/repository/PartyRepository.java
+++ b/src/main/java/com/prgrms/modi/party/repository/PartyRepository.java
@@ -36,5 +36,10 @@ public interface PartyRepository extends JpaRepository<Party, Long>, PartyReposi
 
     int countAllByStatusAndMembersUser(PartyStatus partyStatus, User user);
 
-    int countAllByStatusAndOtt(PartyStatus partyStatus, OTT ott);
+    @Query("SELECT COUNT(p) "
+        + "FROM Party p "
+        + "WHERE p.status = :partyStatus "
+        + "    AND p.ott = :ott "
+        + "    AND (p.currentMember < p.partyMemberCapacity)")
+    long countAvailablePartyByOtt(PartyStatus partyStatus, OTT ott);
 }

--- a/src/main/java/com/prgrms/modi/party/service/PartyService.java
+++ b/src/main/java/com/prgrms/modi/party/service/PartyService.java
@@ -77,7 +77,7 @@ public class PartyService {
         LocalDate minStartDate = LocalDate.of(0, 1, 1);
 
         List<PartyBriefResponse> parties = this.getRecruitingParties(ott, minStartDate, Long.MAX_VALUE, size);
-        Integer partyTotalSize = partyRepository.countAllByStatusAndOtt(PartyStatus.RECRUITING, ott);
+        long partyTotalSize = partyRepository.countAvailablePartyByOtt(PartyStatus.RECRUITING, ott);
 
         return PartyListResponse.from(ott, partyTotalSize, parties);
     }
@@ -88,7 +88,7 @@ public class PartyService {
         Party lastParty = partyRepository.getById(lastPartyId);
 
         List<PartyBriefResponse> parties = this.getRecruitingParties(ott, lastParty.getStartDate(), lastPartyId, size);
-        Integer partyTotalSize = partyRepository.countAllByStatusAndOtt(PartyStatus.RECRUITING, ott);
+        long partyTotalSize = partyRepository.countAvailablePartyByOtt(PartyStatus.RECRUITING, ott);
 
         return PartyListResponse.from(ott, partyTotalSize, parties);
     }


### PR DESCRIPTION
- 이미 시작됐지만 상태가 변경되지 않은 파티 데이터
- 이미 모집이 완료된 파티
위 두 경우 때문에 파티 목록 조회 API에서 잘못된 totalSize 응답해 수정