### PR TITLE
[MODI-274] REFACTOR : 파티가입시 트랜젝션 관리

### DIFF
--- a/src/main/java/com/prgrms/modi/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/modi/error/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.prgrms.modi.error.exception.NotEnoughPartyCapacityException;
 import com.prgrms.modi.error.exception.NotEnoughPointException;
 import com.prgrms.modi.error.exception.NotEnoughUserInformationException;
 import com.prgrms.modi.error.exception.NotFoundException;
+import com.prgrms.modi.error.exception.RequestAgainException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -24,7 +25,7 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler({Exception.class, RequestAgainException.class})
     public ResponseEntity<ErrorResponse> internalServerErrorHandler(Exception e) {
         return ResponseEntity
             .internalServerError()

--- a/src/main/java/com/prgrms/modi/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/prgrms/modi/error/GlobalExceptionHandler.java
@@ -25,11 +25,19 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler({Exception.class, RequestAgainException.class})
+    @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> internalServerErrorHandler(Exception e) {
         return ResponseEntity
             .internalServerError()
             .body(new ErrorResponse(e.getMessage(), "", HttpStatus.INTERNAL_SERVER_ERROR));
+    }
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(RequestAgainException.class)
+    public ResponseEntity<ErrorResponse> requestConflictHandler(RequestAgainException e) {
+        return ResponseEntity
+            .status(HttpStatus.CONFLICT)
+            .body(new ErrorResponse(e.getMessage(), "", HttpStatus.CONFLICT));
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/java/com/prgrms/modi/error/exception/RequestAgainException.java
+++ b/src/main/java/com/prgrms/modi/error/exception/RequestAgainException.java
@@ -1,0 +1,9 @@
+package com.prgrms.modi.error.exception;
+
+public class RequestAgainException extends RuntimeException {
+
+    public RequestAgainException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/prgrms/modi/party/controller/PartyController.java
+++ b/src/main/java/com/prgrms/modi/party/controller/PartyController.java
@@ -42,8 +42,6 @@ public class PartyController {
 
     private final PartyService partyService;
 
-    private final int MAX_ATTEMPT_COUNT = 2;
-
     public PartyController(PartyService partyService) {
         this.partyService = partyService;
     }
@@ -130,13 +128,14 @@ public class PartyController {
         if (partyService.isPartyMember(partyId, authentication.userId)) {
             throw new AlreadyJoinedException("이미 가입한 파티입니다");
         }
-        int requestCount = 0;
-        while(requestCount < MAX_ATTEMPT_COUNT) {
+        int attemptCount = 0;
+        int maxAttemptCount = 2;
+        while(attemptCount < maxAttemptCount) {
             try {
                 PartyIdResponse resp = partyService.joinParty(authentication.userId, partyId);
                 return ResponseEntity.ok(resp);
             } catch (ObjectOptimisticLockingFailureException e) {
-                requestCount++;
+                attemptCount++;
             } catch (DataIntegrityViolationException e) {
                 throw new AlreadyJoinedException("이미 가입한 파티입니다");
             }

--- a/src/main/java/com/prgrms/modi/party/controller/PartyController.java
+++ b/src/main/java/com/prgrms/modi/party/controller/PartyController.java
@@ -137,6 +137,7 @@ public class PartyController {
             } catch (DataIntegrityViolationException e) {
                 throw new AlreadyJoinedException("이미 가입된 파티에 가입할 수 없습니다");
             }
+            requestCount++;
         }
         throw new RequestAgainException("잠시 후에 다시 시도해주세요.");
     }

--- a/src/main/java/com/prgrms/modi/party/controller/PartyController.java
+++ b/src/main/java/com/prgrms/modi/party/controller/PartyController.java
@@ -16,9 +16,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import javax.validation.Valid;
-import javax.validation.constraints.Positive;
-
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
@@ -34,6 +31,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import springfox.documentation.annotations.ApiIgnore;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 
 @RestController
 @RequestMapping("/api")
@@ -127,6 +127,9 @@ public class PartyController {
         if (authentication == null) {
             throw new InvalidAuthenticationException("인증되지 않는 사용자입니다");
         }
+        if (partyService.isPartyMember(partyId, authentication.userId)) {
+            throw new AlreadyJoinedException("이미 가입한 파티입니다");
+        }
         int requestCount = 0;
         while(requestCount < MAX_ATTEMPT_COUNT) {
             try {
@@ -135,11 +138,10 @@ public class PartyController {
             } catch (ObjectOptimisticLockingFailureException e) {
                 requestCount++;
             } catch (DataIntegrityViolationException e) {
-                throw new AlreadyJoinedException("이미 가입된 파티에 가입할 수 없습니다");
+                throw new AlreadyJoinedException("이미 가입한 파티입니다");
             }
-            requestCount++;
         }
-        throw new RequestAgainException("잠시 후에 다시 시도해주세요.");
+        throw new RequestAgainException("잠시 후에 다시 시도해주세요");
     }
 
     @DeleteMapping("/parties/{partyId}")

--- a/src/main/java/com/prgrms/modi/party/domain/Party.java
+++ b/src/main/java/com/prgrms/modi/party/domain/Party.java
@@ -21,6 +21,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import javax.persistence.Version;
 import javax.validation.constraints.FutureOrPresent;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
@@ -85,6 +86,9 @@ public class Party extends DeletableEntity {
 
     @OneToMany(mappedBy = "party", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     private List<PartyRule> partyRules = new ArrayList<>();
+
+    @Version
+    private Integer version;
 
     protected Party() {
     }

--- a/src/main/resources/db/migration/V2021.12.20.2207__addVersionInParty.sql
+++ b/src/main/resources/db/migration/V2021.12.20.2207__addVersionInParty.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `parties`
+    ADD `version` INT NOT NULL;

--- a/src/main/resources/db/migration/V2021.12.21.1053__addUniqueInMember.sql
+++ b/src/main/resources/db/migration/V2021.12.21.1053__addUniqueInMember.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `members`
+    ADD CONSTRAINT `UC_Member` UNIQUE (`party_id`, `user_id`);

--- a/src/test/java/com/prgrms/modi/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/prgrms/modi/party/controller/PartyControllerTest.java
@@ -246,7 +246,7 @@ class PartyControllerTest {
     @DisplayName("파티에 중복 가입을 할 수 없다.")
     @Transactional
     public void alreadyJoinedExceptionTest() throws Exception {
-        Long partyId = 1L;
+        Long partyId = 5L;
         Long userId = 1L;
         User user = userRepository.findById(userId).get();
         int userPoint = 100_000;
@@ -256,7 +256,7 @@ class PartyControllerTest {
             .contentType(MediaType.APPLICATION_JSON))
             .andExpectAll(
                 status().isBadRequest(),
-                jsonPath("$.errorMessage").value("이미 가입된 파티에 가입할 수 없습니다")
+                jsonPath("$.errorMessage").value("이미 가입한 파티입니다")
             )
             .andDo(print());
     }

--- a/src/test/resources/db/seed/R__seed.sql
+++ b/src/test/resources/db/seed/R__seed.sql
@@ -17,16 +17,16 @@ INSERT INTO otts(id, name, english_name, subscription_fee, monthly_price, max_me
         (7, '쿠팡 플레이', 'coupangPlay', 10000, 2500, 4, '프리미엄', '2021-11-01 06:30:00', '2021-11-01 06:30:00'),
         (8, '아마존 프라임', 'amazonPlay', 10000, 2500, 4, '프리미엄', '2021-11-01 06:30:00', '2021-11-01 06:30:00');
 
-INSERT INTO parties(id, party_member_capacity, current_member, total_price, monthly_reimbursement, remaining_reimbursement, start_date, end_date, period, must_filled, shared_id, shared_password_encrypted, status, created_at, updated_at, deleted_at, ott_id)
+INSERT INTO parties(id, party_member_capacity, current_member, total_price, monthly_reimbursement, remaining_reimbursement, start_date, end_date, period, must_filled, shared_id, shared_password_encrypted, status, created_at, updated_at, deleted_at, version, ott_id)
     VALUES
-        (1, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 6, 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),
-        (2, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 6, 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),
-        (3, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 6, 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),
-        (4, 4, 2, 10000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),
-        (5, 4, 2, 10000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),
-        (6, 4, 2, 100000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1),
-        (7, 4, 2, 100000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', '2021-11-02 06:30:00', 1),
-        (8, 4, 1, 100000, 0, 0, '2022-02-12', '2022-05-22', 3, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1);
+        (1, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 6, 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1),
+        (2, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 6, 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1),
+        (3, 4, 4, 10000, 5000, 25000, '2021-11-02', '2022-05-02', 6, 1, 'modi112@gmail.com', 'modi', 'ONGOING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1),
+        (4, 4, 2, 10000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1),
+        (5, 4, 2, 10000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1),
+        (6, 4, 2, 100000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1),
+        (7, 4, 2, 100000, 0, 0, '2021-12-26', '2022-05-02', 5, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', '2021-11-02 06:30:00', 1, 1),
+        (8, 4, 1, 100000, 0, 0, '2022-02-12', '2022-05-22', 3, 1, 'modi112@gmail.com', 'modi', 'RECRUITING', '2021-11-02 06:30:00', '2021-11-01 06:30:00', null, 1, 1);
 
 INSERT INTO rules(id, name, created_at, updated_at)
     VALUES


### PR DESCRIPTION
- DataIntegrationViolationException의 경우, SQLException을 RuntimeException으로 포장하기 위한 DataAceessException에서 파생 된 것이라서 ERROR 로그를 잡지 못했습니다 ㅠ... 차후에 도전해보겠습니다
- 파티 가입 요청을 동일 파티에 계속 할 경우, ERROR 로그가 계속 해서 찍히는 걸 방지하기 위해 과거에 했던 예외처리를 다시 가져왔습니다(마지막 커밋).
- 이러한 기능구현은 처음이라 분명 문제가 많을 듯 합니다. 유심히 봐주시면 감사하겠습니다 ㅠㅠ