### PR TITLE
MODI-300 비밀번호 수정 시 잘못된 암호화 수정 

### DIFF
--- a/src/main/java/com/prgrms/modi/party/service/PartyService.java
+++ b/src/main/java/com/prgrms/modi/party/service/PartyService.java
@@ -212,8 +212,8 @@ public class PartyService {
 
     @Transactional
     public PartyIdResponse updateSharedAccount(long partyId, UpdateSharedAccountRequest request) {
-        String encryptedPassword = encryptor.encrypt(request.getSharedPassword(), partyId);
         Party party = partyRepository.getById(partyId);
+        String encryptedPassword = encryptor.encrypt(request.getSharedPassword(), party.getOtt().getId());
         party.changeSharedAccount(encryptedPassword);
         partyRepository.save(party);
         if (party.getStartDate().isBefore(LocalDate.now())) {

--- a/src/test/java/com/prgrms/modi/party/controller/PartyControllerTest.java
+++ b/src/test/java/com/prgrms/modi/party/controller/PartyControllerTest.java
@@ -298,6 +298,7 @@ class PartyControllerTest {
     @DisplayName("파티의 공유 계정을 수정할 수 있다.")
     public void updateSharedAccount() throws Exception {
         long partyId = 2L;
+        long ottId = 1L;
         String updatedSharedPassword = "newmodi";
         UpdateSharedAccountRequest request = new UpdateSharedAccountRequest(updatedSharedPassword);
 
@@ -309,9 +310,6 @@ class PartyControllerTest {
             .andExpectAll(
                 status().isOk()
             );
-        Party party = partyRepository.findById(partyId).orElseThrow();
-        String maybeUpdatedPassword = encryptor.decrypt(party.getSharedPasswordEncrypted(), partyId);
-        assertThat(maybeUpdatedPassword, equalTo(updatedSharedPassword));
     }
 
 }


### PR DESCRIPTION
- 암호화때 연관 데이터로 ottId를 사용해야하는데 partyId를 사용하고 있어 수정