### PR TITLE
[MODI-291] 알림 기능 - 스케쥴러 관련 알림 구현

### DIFF
--- a/src/main/java/com/prgrms/modi/common/scheduler/ReimbursementScheduler.java
+++ b/src/main/java/com/prgrms/modi/common/scheduler/ReimbursementScheduler.java
@@ -28,6 +28,12 @@ public class ReimbursementScheduler {
         partyService.changeToFinish(today);
     }
 
+    @Scheduled(cron = "0 0 00 * * ?")
+    public void alertParties() {
+        LocalDate today = LocalDate.now();
+        partyService.alertFinishingParty(today);
+    }
+
     @Scheduled(cron = "0 0 05 * * ?")
     public void reimburse() {
         LocalDate today = LocalDate.now();

--- a/src/test/java/com/prgrms/modi/party/service/PartyIntegrationTest.java
+++ b/src/test/java/com/prgrms/modi/party/service/PartyIntegrationTest.java
@@ -1,12 +1,9 @@
 package com.prgrms.modi.party.service;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -88,7 +85,7 @@ public class PartyIntegrationTest {
             .monthlyReimbursement(5000)
             .remainingReimbursement(15000)
             .startDate(LocalDate.now())
-            .endDate(LocalDate.now().plusMonths(1))
+            .endDate(LocalDate.now().plusMonths(2))
             .mustFilled(true)
             .sharedId("testSharedId")
             .sharedPasswordEncrypted("testSharedPw")
@@ -111,7 +108,7 @@ public class PartyIntegrationTest {
             .monthlyReimbursement(5000)
             .remainingReimbursement(15000)
             .startDate(LocalDate.now())
-            .endDate(LocalDate.now().plusMonths(1))
+            .endDate(LocalDate.now().plusMonths(2))
             .mustFilled(true)
             .sharedId("testSharedId")
             .sharedPasswordEncrypted("testSharedPw")
@@ -132,12 +129,15 @@ public class PartyIntegrationTest {
         Long memberId = memberRepository.save(member).getId();
 
         partyService.deleteNotGatheredParties(LocalDate.now());
-        assertThat(partyRepository.findAll(), hasItems(hasProperty("id"), not(partyId)));
-        assertThat(memberRepository.findAll(), hasItems(hasProperty("id"), not(memberId)));
+
+        assertAll(
+            () -> assertThat(partyRepository.findAll(), hasItems(hasProperty("id"), not(partyId))),
+            () -> assertThat(memberRepository.findAll(), hasItems(hasProperty("id"), not(memberId)))
+        );
     }
 
     @Test
-    @DisplayName("파티 기간이 끝나면 FINISH 상태가 되어야 한다.")
+    @DisplayName("파티 기간이 끝나면 FINISHED 상태가 되어야 한다.")
     @Transactional
     public void changeFinishStatus() {
         Party partyWillBeFinished = new Party.Builder()


### PR DESCRIPTION
### 추가한 알림 목록
* 파티원에게 파티가 다 채워지지 않아서 삭제될 때
    * `파티 인원이 다 채워지지 않아 파티가 삭제되었습니다.`
* 파티원에게 파티가 시작되는 날일 때
    * `파티가 오늘부터 시작됩니다.`
* 파티원에게 파티가 1일 후 만료될 때
    * `파티가 1일 후 만료됩니다.`
* 파티원에게 파티가 만료되는 날일 때
    * `파티가 만료되었습니다.`

### 참고
* 자정 기준으로 알림이 생성
* 테스트 추가 구현 필요